### PR TITLE
Add safety check for if damage source has no item

### DIFF
--- a/CalamityPets/SupremeCalamitas.cs
+++ b/CalamityPets/SupremeCalamitas.cs
@@ -56,7 +56,8 @@ namespace PetsOverhaulCalamityAddon.CalamityPets
         }
         public override void ModifyHitNPCWithProj(Projectile proj, NPC target, ref NPC.HitModifiers modifiers)
         {
-            if (PetIsEquipped() && modifiers.DamageType is not SummonDamageClass && proj.TryGetGlobalProjectile(out ProjectileSourceChecks source) && source.itemProjIsFrom.channel == false && ItemIsATool(source.itemProjIsFrom) == false)
+            if (PetIsEquipped() && modifiers.DamageType is not SummonDamageClass && proj.TryGetGlobalProjectile(out ProjectileSourceChecks source) && source.itemProjIsFrom is not null &&
+                source.itemProjIsFrom.channel == false && ItemIsATool(source.itemProjIsFrom) == false)
             {
                 SetCritDmgModifs(ref modifiers);
             }


### PR DESCRIPTION
I received a report pertaining to this in a mod of mine, which includes a boss that makes heavy use of non-item projectiles, such as deflectable missiles. After some investigation I tracked the source of the problem down to this line, with its seeming mistaken assumption that friendly projectiles are sourced from items and such.
Adding a safety check to this item check addressed the problem.